### PR TITLE
[BUGFIX] Missing Bootstrap styles

### DIFF
--- a/Resources/Private/Templates/ViewHelpers/Widget/Upload/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/Upload/Index.html
@@ -33,13 +33,13 @@
 					<span class="qq-upload-file-selector qq-upload-file"></span>
 					<input class="qq-edit-filename-selector qq-edit-filename" tabindex="0" type="text">
 					<span class="qq-upload-size-selector qq-upload-size"></span>
-					<a class="qq-upload-cancel-selector btn-small btn-warning" href="#">Cancel</a>
-					<a class="qq-upload-retry-selector btn-small btn-info" href="#">Retry</a>
-					<a class="qq-upload-delete-selector btn-small btn-warning" href="#">Delete</a>
-					<a class="qq-upload-pause-selector btn-small btn-info" href="#">Pause</a>
-					<a class="qq-upload-continue-selector btn-small btn-info" href="#">Continue</a>
+					<a class="qq-upload-cancel-selector btn btn-small btn-warning" href="#">Cancel</a>
+					<a class="qq-upload-retry-selector btn btn-small btn-info" href="#">Retry</a>
+					<a class="qq-upload-delete-selector btn btn-small btn-warning" href="#">Delete</a>
+					<a class="qq-upload-pause-selector btn btn-small btn-info" href="#">Pause</a>
+					<a class="qq-upload-continue-selector btn btn-small btn-info" href="#">Continue</a>
 					<span class="qq-upload-status-text-selector qq-upload-status-text"></span>
-					<a class="view-btn btn-small btn-info hide" target="_blank">View</a>
+					<a class="view-btn btn btn-small btn-info hide" target="_blank">View</a>
 				</li>
 			</ul>
 		</div>


### PR DESCRIPTION
The upload template uses Bootstrap styles "btn-*" for the various links
but they all miss the base "btn" class.