### PR TITLE
[BUFGIX] adds @-symbol to the exif_read_data() call in getOrientation()

### DIFF
--- a/Classes/FileUpload/Optimizer/Rotate.php
+++ b/Classes/FileUpload/Optimizer/Rotate.php
@@ -77,8 +77,8 @@ class Rotate implements ImageOptimizerInterface
         $extension = strtolower(substr($filename, strrpos($filename, '.') + 1));
         $orientation = 1; // Fallback to "straight"
         if (\TYPO3\CMS\Core\Utility\GeneralUtility::inList('jpg,jpeg,tif,tiff', $extension) && function_exists('exif_read_data')) {
-            $exif = exif_read_data($filename);
-            if ($exif) {
+            $exif = @exif_read_data($filename);
+            if ($exif !== false && is_array($exif) && array_key_exists('Orientation', $exif)) {
                 $orientation = $exif['Orientation'];
             }
         }


### PR DESCRIPTION
The `exif_read_data()` call in `Fab\MediaUpload\FileUpload\Optimizer\Rotate->getOrientation()` sometimes throws warnings, if an image has bad exif data. So the ajax call will result in an error because of the php warning printed out, even if the ajax call returns success = true.

I know, in production PHP warnings are/ should be disabled. But the `unlink` and `rename` calls in this class are also prefixed with an @-symbol, so I suggest to do it here aswell.