### PR TITLE
Fixes retrieving images after upload

### DIFF
--- a/Classes/Service/UploadFileService.php
+++ b/Classes/Service/UploadFileService.php
@@ -43,6 +43,10 @@ class UploadFileService
         $files = array();
         $uploadedFiles = GeneralUtility::trimExplode(',', $this->getUploadedFileList($property), TRUE);
 
+        $uploadedFiles = array_map(function ($item) {
+            return UploadManager::UPLOAD_FOLDER.'/'.$item;
+        }, $uploadedFiles);
+
         // Convert uploaded files into array
         foreach ($uploadedFiles as $uploadedFileName) {
 


### PR DESCRIPTION
This PR fixes #21 by prefixing the uploaded file paths by the temporary storage path in the `UploadFileService`