### PR TITLE
Compatibility87

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ to retrieve them and store them into their final location. This code can be used
 		...
 	}
 
-
+**Note:** for TYPO3 8.7.x you need to change the conflict mode __changeName__ to __DuplicationBehavior::RENAME__ due to [Deprecation: #55419](https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/7.5/Deprecation-55419-StreamlineFileConflictModeHandling.html)
 
 File Configuration in FAL
 =========================

--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,8 @@ to retrieve them and store them into their final location. This code can be used
 		...
 	}
 
-**Note:** for TYPO3 8.7.x you need to change the conflict mode __changeName__ to __DuplicationBehavior::RENAME__ due to [Deprecation: #55419](https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/7.5/Deprecation-55419-StreamlineFileConflictModeHandling.html)
+**Note:** for TYPO3 8.7.x you need to change the conflict mode **changeName** to **DuplicationBehavior::RENAME** due to https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/7.5/Deprecation-55419-StreamlineFileConflictModeHandling.html
+
 File Configuration in FAL
 =========================
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends' =>
                 [
-                    'typo3' => '7.6.0-7.6.99',
+                    'typo3' => '7.6.0-8.7.99',
                 ],
             'conflicts' =>
                 [


### PR DESCRIPTION
For TYPO3 8.7.x you need to change the conflict mode **_changeName_** to **_DuplicationBehavior::RENAME_** due to [Deprecation: #55419](https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/7.5/Deprecation-55419-StreamlineFileConflictModeHandling.html)

Also updated the README file.
I've tested on TYPO3 8.7.10 and everything seems to be fine, great extension btw.