### PR TITLE
Retired ext_typoscript_[setup|constant].txt

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,0 +1,4 @@
+<?php
+if (!defined('TYPO3_MODE')) die ('Access denied.');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Media upload');

--- a/ext_typoscript_constants.txt
+++ b/ext_typoscript_constants.txt
@@ -1,1 +1,0 @@
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:media_upload/Configuration/TypoScript/constants.txt">

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,1 +1,0 @@
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:media_upload/Configuration/TypoScript/setup.txt">


### PR DESCRIPTION
The typoscript settings can not be overwritten if you use ext_typoscript_[setup|constant].txt
because they are loaded last.

Please refer to https://usetypo3.com/good-practices-in-extensions.html

**Please note**: this will require users to include the static typoscript in their root template. This makes the plugin *slightly* less plug and play.