### PR TITLE
[TASK] TYPO3 9.5 compatibility

### DIFF
--- a/Classes/Controller/MediaUploadController.php
+++ b/Classes/Controller/MediaUploadController.php
@@ -142,7 +142,6 @@ class MediaUploadController extends ActionController
      * @return void
      * @throws \TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotReturnException
      * @throws \TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotException
-     * @signal
      */
     protected function emitBeforeHandleUploadSignal()
     {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,7 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Fabien Udriot',
     'author_email' => 'fabien@ecodev.ch',
     'state' => 'beta',
-    'version' => '1.1.0-dev',
+    'version' => '1.1.1-dev',
     'autoload' => [
         'psr-4' => ['Fab\\MediaUpload\\' => 'Classes']
     ],
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends' =>
                 [
-                    'typo3' => '7.6.0-8.7.99',
+                    'typo3' => '7.6.0-9.5.99',
                 ],
             'conflicts' =>
                 [


### PR DESCRIPTION
Removed @signal from emitBeforeHandleUploadSignal as this causes errors in TYPO3 9.5
Changes constraints to allow TYPO3 9.5