### PR TITLE
added format.raw to allowed extensions

### DIFF
--- a/Resources/Private/Templates/ViewHelpers/Widget/Upload/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/Upload/Index.html
@@ -50,7 +50,7 @@
 		var storage= '{storage}';
 		var uniqueId= '{uniqueId}';
 		var property= '{property}';
-		var allowedExtensions= ['{allowedExtensions}'];
+		var allowedExtensions= ['<f:format.raw>{allowedExtensions}</f:format.raw>'];
 
 		var typeError = "{f:translate(key: 'fineUploader.message.errorType')}";
 		var sizeError = "{f:translate(key: 'fineUploader.message.sizeError')}";


### PR DESCRIPTION
I had to change the output of the allowedExtensions with format.raw in Fluid because some characters are escaped in the output of the document.