### PR TITLE
[BUGFIX] Set paramsInBody to false

### DIFF
--- a/Resources/Public/Build/media_upload.js
+++ b/Resources/Public/Build/media_upload.js
@@ -3462,7 +3462,7 @@ qq.status = {
                 inputName: "qqfile",
                 method: "POST",
                 params: {},
-                paramsInBody: true,
+                paramsInBody: false,
                 totalFileSizeName: "qqtotalfilesize",
                 uuidName: "qquuid"
             },


### PR DESCRIPTION
Set paramsInBody to false to make it work with TYPO3 9.5, fixes #42 