### PR TITLE
[CHORE] Add version to ext_emconf.php and composer.json

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,6 +7,7 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Fabien Udriot',
     'author_email' => 'fabien@ecodev.ch',
     'state' => 'stable',
+    'version' => '3.0.4',
     'autoload' => [
         'psr-4' => ['Fab\\MediaUpload\\' => 'Classes']
     ],


### PR DESCRIPTION
Commit [5740f96](https://github.com/fabarea/media_upload/commit/5740f9614ed48f7406cf96d7775efec542f42d6d) removed the version from `ext_emconf.php`.

This PR now adds the current version `3.0.4` to both the `composer.json` and `ext_emconf.php`.

This helps TYPO3 and other tools to properly determine the currently installed version of the extension.